### PR TITLE
Make input case insensitive + bugfix

### DIFF
--- a/jooby
+++ b/jooby
@@ -54,7 +54,7 @@ artifactid(){
 
 version(){
   echo -n "Enter your project's version (current: ${VERSION}) "
-  read ARTIFACTID
+  read VERSION
 }
 
 go(){
@@ -77,13 +77,13 @@ read_options() {
     3)
       version
       ;;
-    R)
+    R|r)
       start_jooby_app
       ;;
-    G)
+    G|g)
       go
       ;;
-    Q)
+    Q|q)
       exit 0;;
     *)
       echo -e "${RED}Error...${STD}" && sleep 1


### PR DESCRIPTION
- Allow the user to enter R, G and Q in both upper and lower case.
- Store the project version in the correct variable.